### PR TITLE
Add STACKERS Five & Slide game with engine and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,37 @@
-# hello-world
-Just another repository
-Hi, world...my name is Conner Smith. I'm excited to learn about webdesign.
+# STACKERS: Five & Slide
+
+A lightweight Vite + React + TypeScript implementation of the abstract game. Includes a pure rules engine with Vitest coverage and a clickable UI.
+
+## Getting started
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Run the dev server (binds to `0.0.0.0:4173` for the preview):
+
+```bash
+npm run dev
+```
+
+Run tests:
+
+```bash
+npm test
+```
+
+### How to play in this preview
+- Click a stack that has your color on top to select it, pick direction and segment size, then press **Move**.
+- **Place** drops a new token into the lowest legal space (obeying the special slot rules).
+- **Bubble Up** becomes available only when you cannot move or place; click it then choose one of your pinned tokens to lift it to the top.
+- Exiting 5 of your tokens (moving forward off space 8) wins immediately.
+
+## Rules summary (implemented in engine)
+- Board spaces 1–8 each hold a bottom→top stack (array index 0 is bottom). Exit is beyond space 8.
+- On your turn take exactly one action: **move** a top stack segment one space (with Five & Slide), **place** a new token, or **bubble up** if you are stuck.
+- Move: only your contiguous top tokens may move, distance exactly 1 forward/backward. Landing on opponents pins them. If destination has 5 tokens, slide forward past any 5-stacks; sliding is always forward. Landing stacks may never exceed 5 tokens. Moving forward off space 8 exits tokens and counts toward victory.
+- Place: into the lowest empty space; if spaces 2–7 are filled and space 1 is empty you must place there; if spaces 1–7 are filled you may place in space 8. Forced to place when you have unplaced tokens, an empty space, and no legal moves.
+- Bubble Up: only when you have no legal move and cannot place; choose one of your pinned tokens to move it to the top of its stack.
+- Red starts; turn passes unless a winning exit occurs.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>STACKERS: Five & Slide</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "stackers-five-and-slide",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host --port 4173",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview --host --port 4173",
+    "test": "vitest"
+  },
+  "dependencies": {
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "typescript": "^5.5.2",
+    "vite": "^5.3.1",
+    "vitest": "^2.0.4",
+    "jsdom": "^24.1.0"
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,201 @@
+import { useMemo, useState } from 'react';
+import {
+  applyAction,
+  canPlace,
+  getBubbleOptions,
+  getLegalActions,
+  getMoveOptions,
+  placementDestination,
+  topContiguousCount,
+  isPinned
+} from './engine/engine';
+import { createInitialState } from './engine/state';
+import { BubbleAction, GameState, MoveAction, Player } from './engine/types';
+
+function tokenClass(player: Player) {
+  return player === 'RED' ? 'token red' : 'token blue';
+}
+
+function formatPlayer(player: Player) {
+  return player === 'RED' ? 'Red' : 'Blue';
+}
+
+function useGameState() {
+  const [state, setState] = useState<GameState>(createInitialState());
+  const reset = () => setState(createInitialState());
+  const dispatch = (action: BubbleAction | MoveAction | { type: 'place' }) => {
+    setState((prev) => applyAction(prev, action));
+  };
+  return { state, reset, dispatch };
+}
+
+export default function App() {
+  const { state, reset, dispatch } = useGameState();
+  const [selectedSpace, setSelectedSpace] = useState<number | null>(null);
+  const [direction, setDirection] = useState<'forward' | 'backward'>('forward');
+  const [segmentSize, setSegmentSize] = useState(1);
+  const [bubbleMode, setBubbleMode] = useState(false);
+  const legalActions = useMemo(() => getLegalActions(state), [state]);
+  const moveOptions = useMemo(() => getMoveOptions(state), [state]);
+  const bubbleOptions = useMemo(() => getBubbleOptions(state), [state]);
+  const placeLegal = canPlace(state);
+  const bubbleAllowed = bubbleOptions.length > 0 && moveOptions.length === 0 && !placeLegal;
+  const placementTarget = placementDestination(state);
+  const placementLabel = placementTarget === null ? '—' : placementTarget + 1;
+
+  const topCount = selectedSpace !== null ? topContiguousCount(state.board[selectedSpace], state.currentPlayer) : 0;
+
+  const attemptMove = () => {
+    if (selectedSpace === null) return;
+    const action: MoveAction = { type: 'move', from: selectedSpace, dir: direction, count: segmentSize };
+    const isLegal = legalActions.some(
+      (a) => a.type === 'move' && a.from === action.from && a.dir === action.dir && a.count === action.count
+    );
+    if (!isLegal) return;
+    dispatch(action);
+    setSelectedSpace(null);
+  };
+
+  const attemptPlace = () => {
+    const isLegal = legalActions.some((a) => a.type === 'place');
+    if (isLegal) {
+      dispatch({ type: 'place' });
+      setSelectedSpace(null);
+    }
+  };
+
+  const attemptBubble = (space: number, tokenIndex: number) => {
+    const action: BubbleAction = { type: 'bubble', space, tokenIndex };
+    const isLegal = legalActions.some(
+      (a) => a.type === 'bubble' && a.space === action.space && a.tokenIndex === action.tokenIndex
+    );
+    if (!isLegal) return;
+    dispatch(action);
+    setBubbleMode(false);
+    setSelectedSpace(null);
+  };
+
+  const handleSpaceClick = (spaceIndex: number) => {
+    if (bubbleMode) return;
+    const count = topContiguousCount(state.board[spaceIndex], state.currentPlayer);
+    if (count === 0) return;
+    setSelectedSpace(spaceIndex);
+    setSegmentSize(Math.min(segmentSize, count) || 1);
+  };
+
+  const currentLegalMoveDirections = useMemo(() => {
+    if (selectedSpace === null) return [] as ('forward' | 'backward')[];
+    return moveOptions
+      .filter((m) => m.from === selectedSpace)
+      .map((m) => m.dir);
+  }, [selectedSpace, moveOptions]);
+
+  const info = state.winner ? `${formatPlayer(state.winner)} wins!` : `${formatPlayer(state.currentPlayer)} to act`;
+
+  return (
+    <div className="app">
+      <div className="header">
+        <div>
+          <h1>STACKERS: Five & Slide</h1>
+          <div className="legend">Stacks are bottom → top in reading order.</div>
+        </div>
+        <button onClick={reset}>Reset</button>
+      </div>
+      <div className="message">{info}</div>
+      <div className="message">
+        Unplaced – Red: {state.unplaced.RED}, Blue: {state.unplaced.BLUE} | Exited – Red: {state.exited.RED}, Blue:{' '}
+        {state.exited.BLUE}
+      </div>
+      <div className="board">
+        {state.board.map((stack, idx) => (
+          <div key={idx} className="space">
+            <div className="space-label">{idx + 1}</div>
+            <div className="stack" onClick={() => handleSpaceClick(idx)}>
+              {stack.map((token, tIdx) => {
+                const isTop = tIdx === stack.length - 1;
+                const isCurrentPlayer = token.player === state.currentPlayer;
+                const selectable = isCurrentPlayer && isTop && !bubbleMode;
+                const pinnedSelectable = bubbleMode && isCurrentPlayer && isPinned(stack, tIdx) && bubbleAllowed;
+                return (
+                  <div
+                    key={tIdx}
+                    className={tokenClass(token.player)}
+                    style={{ opacity: selectable || pinnedSelectable ? 1 : 0.7, borderColor: selectable ? '#fb7185' : undefined }}
+                    onClick={() => {
+                      if (pinnedSelectable) attemptBubble(idx, tIdx);
+                      else if (selectable) handleSpaceClick(idx);
+                    }}
+                  >
+                    {token.player === 'RED' ? 'R' : 'B'}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <div className="controls">
+        <div className="control-card">
+          <h3>Move</h3>
+          <div>Direction:</div>
+          <div style={{ display: 'flex', gap: '0.5rem', margin: '0.25rem 0' }}>
+            <button
+              onClick={() => setDirection('forward')}
+              disabled={!currentLegalMoveDirections.includes('forward')}
+              style={{ background: direction === 'forward' ? '#c7d2fe' : undefined }}
+            >
+              Forward
+            </button>
+            <button
+              onClick={() => setDirection('backward')}
+              disabled={!currentLegalMoveDirections.includes('backward')}
+              style={{ background: direction === 'backward' ? '#c7d2fe' : undefined }}
+            >
+              Backward
+            </button>
+          </div>
+          <div>
+            Segment size:{' '}
+            <select value={segmentSize} onChange={(e) => setSegmentSize(Number(e.target.value))}>
+              {Array.from({ length: topCount }, (_, i) => i + 1).map((n) => (
+                <option key={n} value={n}>
+                  {n}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="selection-info">
+            Selected space: {selectedSpace !== null ? selectedSpace + 1 : 'none'}
+          </div>
+          <button onClick={attemptMove} disabled={!legalActions.some((a) => a.type === 'move')}>
+            Move
+          </button>
+        </div>
+
+        <div className="control-card">
+          <h3>Place</h3>
+          <div>Lowest empty slot: {placementLabel}</div>
+          <button onClick={attemptPlace} disabled={!legalActions.some((a) => a.type === 'place')}>
+            Place token
+          </button>
+        </div>
+
+        <div className="control-card">
+          <h3>Bubble Up</h3>
+          <button onClick={() => setBubbleMode(true)} disabled={!bubbleAllowed}>
+            Start bubble
+          </button>
+          {bubbleMode && <div>Click a pinned token you own.</div>}
+        </div>
+      </div>
+
+      {state.message && <div className="message">{state.message}</div>}
+      <div className="message">
+        Tip: if you cannot move and have unplaced tokens with an empty space, you must place. Bubble Up is only for when
+        you are fully stuck.
+      </div>
+      <div className="message">Turn order: Red starts. Current player: {formatPlayer(state.currentPlayer)}</div>
+    </div>
+  );
+}

--- a/src/engine/engine.test.ts
+++ b/src/engine/engine.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import { applyAction, getLegalActions, getMoveOptions, placementDestination, topContiguousCount } from './engine';
+import { createInitialState } from './state';
+import { GameState, Player } from './types';
+
+function withState(partial: Partial<GameState>): GameState {
+  const base = createInitialState();
+  return {
+    ...base,
+    ...partial,
+    board: partial.board ?? base.board,
+    unplaced: partial.unplaced ?? base.unplaced,
+    exited: partial.exited ?? base.exited,
+    currentPlayer: partial.currentPlayer ?? base.currentPlayer,
+    winner: partial.winner ?? base.winner
+  };
+}
+
+function token(player: Player) {
+  return { player };
+}
+
+describe('movement restrictions', () => {
+  it('only allows moving from top of mixed stacks', () => {
+    const state = withState({
+      board: [
+        [token('RED'), token('BLUE'), token('RED')],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    const moves = getMoveOptions(state).filter((m) => m.from === 0);
+    expect(moves.every((m) => m.count === 1)).toBe(true);
+  });
+
+  it('counts contiguous tokens for segment selection', () => {
+    const state = withState({
+      board: [
+        [token('BLUE'), token('RED'), token('RED')],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    const count = topContiguousCount(state.board[0], 'RED');
+    expect(count).toBe(2);
+  });
+});
+
+describe('pinning and exiting', () => {
+  it('pins when moving forward and backward', () => {
+    const base = withState({
+      board: [
+        [token('BLUE')],
+        [token('BLUE')],
+        [],
+        [],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    const forward = applyAction(base, { type: 'move', from: 2, dir: 'forward', count: 1 });
+    expect(forward.board[3][forward.board[3].length - 1].player).toBe('RED');
+    const backward = applyAction(base, { type: 'move', from: 2, dir: 'backward', count: 1 });
+    expect(backward.board[1][backward.board[1].length - 1].player).toBe('RED');
+  });
+
+  it('exits from space 8 and wins at five', () => {
+    const state = withState({
+      board: [[], [], [], [], [], [], [], [token('RED'), token('RED')]],
+      currentPlayer: 'RED',
+      exited: { RED: 4, BLUE: 0 }
+    });
+    const after = applyAction(state, { type: 'move', from: 7, dir: 'forward', count: 2 });
+    expect(after.exited.RED).toBe(6);
+    expect(after.winner).toBe('RED');
+  });
+});
+
+describe('five and slide', () => {
+  it('slides past single full stack', () => {
+    const state = withState({
+      board: [
+        [token('RED')],
+        Array(5).fill(token('BLUE')),
+        [],
+        [],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    const after = applyAction(state, { type: 'move', from: 0, dir: 'forward', count: 1 });
+    expect(after.board[2].at(-1)?.player).toBe('RED');
+  });
+
+  it('slides past multiple full stacks', () => {
+    const state = withState({
+      board: [
+        [token('RED')],
+        Array(5).fill(token('BLUE')),
+        Array(5).fill(token('BLUE')),
+        [],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    const after = applyAction(state, { type: 'move', from: 0, dir: 'forward', count: 1 });
+    expect(after.board[3].at(-1)?.player).toBe('RED');
+  });
+
+  it('slides forward even on backward move', () => {
+    const state = withState({
+      board: [
+        [],
+        [],
+        Array(5).fill(token('BLUE')),
+        [token('RED')],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    const after = applyAction(state, { type: 'move', from: 2, dir: 'backward', count: 1 });
+    expect(after.board[1].length).toBe(5);
+    expect(after.board[2][after.board[2].length - 1].player).toBe('RED');
+  });
+});
+
+describe('placement rules', () => {
+  it('forces placement into space 1 when 2-7 are filled', () => {
+    const state = withState({
+      board: [[], [token('BLUE')], [token('BLUE')], [token('BLUE')], [token('BLUE')], [token('BLUE')], [token('BLUE')], []],
+      currentPlayer: 'RED'
+    });
+    expect(placementDestination(state)).toBe(0);
+  });
+
+  it('allows placement into space 8 when 1-7 filled', () => {
+    const state = withState({
+      board: [
+        [token('BLUE')],
+        [token('BLUE')],
+        [token('BLUE')],
+        [token('BLUE')],
+        [token('BLUE')],
+        [token('BLUE')],
+        [token('BLUE')],
+        []
+      ],
+      currentPlayer: 'RED'
+    });
+    expect(placementDestination(state)).toBe(7);
+  });
+
+  it('enforces forced placement when no moves but empty exists', () => {
+    const state = withState({
+      board: [[token('RED')], [token('BLUE')], [], [], [], [], [], []],
+      currentPlayer: 'RED',
+      unplaced: { RED: 7, BLUE: 7 }
+    });
+    const legal = getLegalActions(state);
+    expect(legal).toEqual([{ type: 'place' }]);
+  });
+});
+
+describe('bubble up', () => {
+  it('only available when no moves and no placement and moves token to top', () => {
+    const state = withState({
+      board: [
+        [token('BLUE'), token('RED')],
+        [],
+        [],
+        [],
+        [],
+        [],
+        [],
+        []
+      ],
+      currentPlayer: 'RED',
+      unplaced: { RED: 0, BLUE: 7 }
+    });
+    const legal = getLegalActions(state);
+    expect(legal).toContainEqual({ type: 'bubble', space: 0, tokenIndex: 0 });
+    const after = applyAction(state, { type: 'bubble', space: 0, tokenIndex: 0 });
+    expect(after.board[0].at(-1)?.player).toBe('RED');
+  });
+});

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -1,0 +1,215 @@
+import { GameState, LegalAction, MoveAction, Player, Token } from './types';
+import { oppositePlayer } from './state';
+
+function cloneBoard(board: Token[][]): Token[][] {
+  return board.map((stack) => [...stack]);
+}
+
+export function isPinned(stack: Token[], index: number): boolean {
+  return index < stack.length - 1;
+}
+
+export function topContiguousCount(stack: Token[], player: Player): number {
+  let count = 0;
+  for (let i = stack.length - 1; i >= 0; i--) {
+    if (stack[i].player === player) {
+      count++;
+    } else {
+      break;
+    }
+  }
+  return count;
+}
+
+export function lowestEmptyIndex(board: Token[][]): number {
+  return board.findIndex((space) => space.length === 0);
+}
+
+function spacesFilled(board: Token[][], start: number, end: number): boolean {
+  for (let i = start; i <= end; i++) {
+    if (board[i].length === 0) return false;
+  }
+  return true;
+}
+
+export function placementDestination(state: GameState): number | null {
+  const { board } = state;
+  const empty = lowestEmptyIndex(board);
+  if (empty === -1) return null;
+
+  const spaces2to7Filled = spacesFilled(board, 1, 6);
+  if (spaces2to7Filled && board[0].length === 0) {
+    return 0;
+  }
+
+  const spaces1to7Filled = spacesFilled(board, 0, 6);
+  if (spaces1to7Filled && board[7].length === 0) {
+    return 7;
+  }
+
+  return empty;
+}
+
+export function canPlace(state: GameState): boolean {
+  const dest = placementDestination(state);
+  return dest !== null && state.unplaced[state.currentPlayer] > 0 && state.board[dest].length < 5;
+}
+
+function computeLanding(
+  board: Token[][],
+  from: number,
+  dir: 'forward' | 'backward'
+): { type: 'space'; index: number } | { type: 'exit' } | null {
+  const delta = dir === 'forward' ? 1 : -1;
+  const target = from + delta;
+  if (target < 0) return null;
+  let pos = target;
+  while (pos < 8 && board[pos].length >= 5) {
+    pos += 1;
+  }
+  if (pos >= 8) {
+    return { type: 'exit' };
+  }
+  return { type: 'space', index: pos };
+}
+
+export function getMoveOptions(state: GameState): MoveAction[] {
+  const moves: MoveAction[] = [];
+  const player = state.currentPlayer;
+  state.board.forEach((stack, idx) => {
+    const maxCount = topContiguousCount(stack, player);
+    if (maxCount === 0) return;
+    const counts = Array.from({ length: maxCount }, (_, i) => i + 1);
+    for (const dir of ['forward', 'backward'] as const) {
+      for (const count of counts) {
+        const previewBoard = cloneBoard(state.board);
+        previewBoard[idx] = previewBoard[idx].slice(0, previewBoard[idx].length - count);
+        const landing = computeLanding(previewBoard, idx, dir);
+        if (!landing) continue;
+        if (landing.type === 'space') {
+          const destSize = previewBoard[landing.index].length;
+          if (destSize + count > 5) continue;
+        }
+        moves.push({ type: 'move', from: idx, dir, count });
+      }
+    }
+  });
+  return moves;
+}
+
+export function getBubbleOptions(state: GameState): { space: number; tokenIndex: number }[] {
+  const options: { space: number; tokenIndex: number }[] = [];
+  const player = state.currentPlayer;
+  state.board.forEach((stack, space) => {
+    stack.forEach((token, idx) => {
+      if (token.player === player && isPinned(stack, idx)) {
+        options.push({ space, tokenIndex: idx });
+      }
+    });
+  });
+  return options;
+}
+
+export function getLegalActions(state: GameState): LegalAction[] {
+  if (state.winner) return [];
+  const moveOptions = getMoveOptions(state);
+  const dest = placementDestination(state);
+  const placementLegal = dest !== null && state.unplaced[state.currentPlayer] > 0 && state.board[dest].length < 5;
+
+  const legal: LegalAction[] = [];
+  if (moveOptions.length > 0) {
+    legal.push(...moveOptions);
+    if (placementLegal) {
+      legal.push({ type: 'place' });
+    }
+    return legal;
+  }
+
+  if (placementLegal) {
+    legal.push({ type: 'place' });
+    return legal;
+  }
+
+  const bubbleOptions = getBubbleOptions(state);
+  if (bubbleOptions.length > 0) {
+    legal.push(...bubbleOptions.map((b) => ({ type: 'bubble', ...b })));
+  }
+  return legal;
+}
+
+function applyMove(state: GameState, action: MoveAction): GameState {
+  const { from, dir, count } = action;
+  const player = state.currentPlayer;
+  const board = cloneBoard(state.board);
+  const sourceStack = board[from];
+  const moved = sourceStack.splice(sourceStack.length - count, count);
+
+  const landing = computeLanding(board, from, dir);
+  if (!landing) return state;
+
+  let message: string | undefined;
+  const newExited = { ...state.exited } as Record<Player, number>;
+  if (landing.type === 'exit') {
+    newExited[player] += moved.length;
+    message = `${player} exited ${moved.length} token(s).`;
+  } else {
+    board[landing.index].push(...moved);
+  }
+
+  const winner = newExited[player] >= 5 ? player : null;
+  const nextPlayer = winner ? state.currentPlayer : oppositePlayer(state.currentPlayer);
+
+  return {
+    ...state,
+    board,
+    exited: newExited,
+    currentPlayer: nextPlayer,
+    winner,
+    message
+  };
+}
+
+function applyPlace(state: GameState): GameState {
+  const dest = placementDestination(state);
+  if (dest === null || state.unplaced[state.currentPlayer] <= 0 || state.board[dest].length >= 5) {
+    return state;
+  }
+  const board = cloneBoard(state.board);
+  board[dest].push({ player: state.currentPlayer });
+  const unplaced = { ...state.unplaced } as Record<Player, number>;
+  unplaced[state.currentPlayer] -= 1;
+  return {
+    ...state,
+    board,
+    unplaced,
+    currentPlayer: oppositePlayer(state.currentPlayer),
+    message: `Placed on space ${dest + 1}`
+  };
+}
+
+function applyBubble(state: GameState, space: number, tokenIndex: number): GameState {
+  const board = cloneBoard(state.board);
+  const stack = board[space];
+  const [token] = stack.splice(tokenIndex, 1);
+  stack.push(token);
+  return {
+    ...state,
+    board,
+    currentPlayer: oppositePlayer(state.currentPlayer),
+    message: 'Bubbled up'
+  };
+}
+
+export function applyAction(state: GameState, action: LegalAction): GameState {
+  if (state.winner) return state;
+  switch (action.type) {
+    case 'move':
+      return applyMove(state, action);
+    case 'place':
+      return applyPlace(state);
+    case 'bubble':
+      return applyBubble(state, action.space, action.tokenIndex);
+    default:
+      return state;
+  }
+}

--- a/src/engine/state.ts
+++ b/src/engine/state.ts
@@ -1,0 +1,18 @@
+import { GameState, Player, Token } from './types';
+
+export const INITIAL_TOKENS = 7;
+
+export function createInitialState(): GameState {
+  return {
+    board: Array.from({ length: 8 }, () => [] as Token[]),
+    unplaced: { RED: INITIAL_TOKENS, BLUE: INITIAL_TOKENS },
+    exited: { RED: 0, BLUE: 0 },
+    currentPlayer: 'RED',
+    winner: null,
+    message: undefined
+  };
+}
+
+export function oppositePlayer(player: Player): Player {
+  return player === 'RED' ? 'BLUE' : 'RED';
+}

--- a/src/engine/types.ts
+++ b/src/engine/types.ts
@@ -1,0 +1,34 @@
+export type Player = 'RED' | 'BLUE';
+
+export interface Token {
+  player: Player;
+}
+
+// Stacks are stored from bottom (index 0) to top (last index).
+export interface GameState {
+  board: Token[][];
+  unplaced: Record<Player, number>;
+  exited: Record<Player, number>;
+  currentPlayer: Player;
+  winner: Player | null;
+  message?: string;
+}
+
+export type MoveAction = {
+  type: 'move';
+  from: number; // 0-based space index
+  dir: 'forward' | 'backward';
+  count: number; // number of contiguous tokens from the top
+};
+
+export type PlaceAction = {
+  type: 'place';
+};
+
+export type BubbleAction = {
+  type: 'bubble';
+  space: number;
+  tokenIndex: number; // index inside the stack being bubbled
+};
+
+export type LegalAction = MoveAction | PlaceAction | BubbleAction;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,0 +1,122 @@
+:root {
+  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+body {
+  margin: 0;
+}
+
+.app {
+  padding: 1.5rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.board {
+  display: grid;
+  grid-template-columns: repeat(8, 1fr);
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.space {
+  border: 2px solid #cbd5e1;
+  border-radius: 12px;
+  padding: 0.5rem;
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: #fff;
+  position: relative;
+}
+
+.space-label {
+  position: absolute;
+  top: 6px;
+  left: 8px;
+  font-size: 0.8rem;
+  color: #475569;
+}
+
+.stack {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 100%;
+  gap: 6px;
+  margin-top: 1.25rem;
+}
+
+.token {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  margin: 0 auto;
+  border: 2px solid #0f172a33;
+  box-shadow: inset 0 1px 2px rgba(0, 0, 0, 0.25);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #0f172a;
+  font-weight: bold;
+}
+
+.token.red { background: #fca5a5; }
+.token.blue { background: #bfdbfe; }
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+}
+
+.control-card {
+  border: 1px solid #cbd5e1;
+  border-radius: 10px;
+  padding: 0.75rem;
+  background: #fff;
+}
+
+button {
+  padding: 0.5rem 0.75rem;
+  border-radius: 8px;
+  border: 1px solid #94a3b8;
+  background: #e2e8f0;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.selection-info {
+  margin-top: 0.5rem;
+  font-size: 0.95rem;
+  color: #0f172a;
+}
+
+.message {
+  margin-top: 0.75rem;
+  padding: 0.5rem;
+  border-radius: 8px;
+  background: #f1f5f9;
+  border: 1px solid #cbd5e1;
+}
+
+.legend {
+  font-size: 0.9rem;
+  color: #334155;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "allowSyntheticDefaultImports": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "skipLibCheck": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom'
+  }
+});


### PR DESCRIPTION
## Summary
- set up a Vite + React + TypeScript project with styles and README for STACKERS: Five & Slide
- implement pure rules engine with movement, placement, sliding, and bubble mechanics plus unit tests
- build a playable UI that visualizes stacks and supports move, place, and bubble actions

## Testing
- npm test *(fails: unable to download npm dependencies in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69444fa9becc832298b7f4726656024b)