### PR TITLE
Refine overflow sliding rules and tidy labels

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -126,7 +126,7 @@ body {
 .space {
   border: 2px solid #cbd5e1;
   border-radius: 12px;
-  padding: 0.35rem 0.4rem;
+  padding: 1.2rem 0.4rem 0.35rem;
   min-height: calc(var(--stack-height) + 2rem);
   display: flex;
   flex-direction: column;
@@ -142,6 +142,7 @@ body {
   flex: 1.5 1 0;
   align-items: stretch;
   background: #ebecec;
+  padding-top: 1.6rem;
 }
 
 .space.highlight,
@@ -161,6 +162,12 @@ body {
   left: 8px;
   font-size: 0.8rem;
   color: #475569;
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  pointer-events: none;
+  z-index: 2;
 }
 
 .stack {
@@ -178,6 +185,7 @@ body {
   flex-direction: column;
   gap: 0.35rem;
   width: 100%;
+  margin-top: 0.25rem;
 }
 
 .exit-row {
@@ -242,6 +250,7 @@ body {
   flex-direction: column;
   gap: 0.5rem;
   background: #ebecec;
+  padding-top: 1.6rem;
 }
 
 .exit-stack {


### PR DESCRIPTION
## Summary
- allow multi-token segments to overfill stacks then slide forward or backward per rules while capping stacks at five
- update move generation and landing predictions alongside new coverage for overflow and exit scenarios
- adjust Start and Exit tile styling to prevent label overlap

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945d3f8c6748322b8955cf50fa0aa13)