### PR TITLE
Add local hotseat mode and update room id handling

### DIFF
--- a/src/controllers/hotseatController.ts
+++ b/src/controllers/hotseatController.ts
@@ -1,0 +1,89 @@
+import { applyAction, getLegalActions } from '../engine/engine';
+import { chooseBotAction } from '../engine/bots';
+import { createInitialState } from '../engine/state';
+import { GameState, LegalAction, PlayerInfo } from '../engine/types';
+import { GameController } from './types';
+
+export class HotseatController implements GameController {
+  public kind: GameController['kind'] = 'hotseat';
+  public role: GameController['role'] = 'host';
+  private state: GameState | null = null;
+  private players: PlayerInfo[] = [];
+  private stateCallbacks: ((state: GameState) => void)[] = [];
+  private playerCallbacks: ((players: PlayerInfo[]) => void)[] = [];
+  private botTimer: number | null = null;
+
+  startGame(players: PlayerInfo[]) {
+    this.players = players;
+    this.state = createInitialState(players);
+    this.emitState();
+    this.emitPlayers();
+    this.scheduleBot();
+  }
+
+  getState() {
+    return this.state;
+  }
+
+  getPlayers() {
+    return this.players;
+  }
+
+  getAssignedPlayer() {
+    return null;
+  }
+
+  setPlayers(players: PlayerInfo[]) {
+    this.players = players;
+    this.emitPlayers();
+  }
+
+  submitAction(action: LegalAction) {
+    if (!this.state || this.state.winner) return;
+    const legal = getLegalActions(this.state).some((candidate) => JSON.stringify(candidate) === JSON.stringify(action));
+    if (!legal) return;
+    this.state = applyAction(this.state, action);
+    this.emitState();
+    this.scheduleBot();
+  }
+
+  onStateChange(callback: (state: GameState) => void) {
+    this.stateCallbacks.push(callback);
+  }
+
+  onPlayersChange(callback: (players: PlayerInfo[]) => void) {
+    this.playerCallbacks.push(callback);
+  }
+
+  dispose() {
+    if (this.botTimer) {
+      clearTimeout(this.botTimer);
+      this.botTimer = null;
+    }
+  }
+
+  private emitPlayers() {
+    this.playerCallbacks.forEach((cb) => cb(this.players));
+  }
+
+  private emitState() {
+    if (this.state) {
+      this.stateCallbacks.forEach((cb) => cb(this.state!));
+    }
+  }
+
+  private scheduleBot() {
+    if (!this.state) return;
+    const player = this.state.players[this.state.currentIndex];
+    if (!player || player.kind !== 'bot' || this.state.winner) return;
+    if (this.botTimer) {
+      clearTimeout(this.botTimer);
+    }
+    this.botTimer = window.setTimeout(() => {
+      const action = chooseBotAction(this.state!, player.difficulty || 'medium');
+      if (action) {
+        this.submitAction(action);
+      }
+    }, 500);
+  }
+}

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -1,0 +1,16 @@
+import { GameState, LegalAction, PlayerInfo } from '../engine/types';
+
+export interface GameController {
+  kind: 'hotseat' | 'network';
+  role: 'host' | 'client' | 'local';
+  startGame(players: PlayerInfo[]): void | Promise<void>;
+  getState(): GameState | null;
+  getPlayers(): PlayerInfo[];
+  getAssignedPlayer(): PlayerInfo | null;
+  submitAction(action: LegalAction): void;
+  onStateChange(callback: (state: GameState) => void): void;
+  onPlayersChange(callback: (players: PlayerInfo[]) => void): void;
+  onPlayerJoin?(callback: (player: PlayerInfo) => void): void;
+  setPlayers?(players: PlayerInfo[]): void;
+  dispose(): void;
+}

--- a/src/utils/ids.ts
+++ b/src/utils/ids.ts
@@ -1,0 +1,42 @@
+const CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789';
+
+export function makeRoomId() {
+  const cryptoObj = globalThis.crypto as Crypto & { randomBytes?: (size: number) => Uint8Array };
+  if (cryptoObj?.getRandomValues) {
+    const buf = new Uint8Array(16);
+    cryptoObj.getRandomValues(buf);
+    return Array.from(buf)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  if (typeof cryptoObj?.randomBytes === 'function') {
+    const buf = cryptoObj.randomBytes(16);
+    return Array.from(buf as unknown as Uint8Array)
+      .map((b) => b.toString(16).padStart(2, '0'))
+      .join('');
+  }
+  return `${Date.now().toString(16)}-${Math.random().toString(16).slice(2)}`;
+}
+
+function pickChar() {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+  if (cryptoObj?.getRandomValues) {
+    const buf = new Uint32Array(1);
+    cryptoObj.getRandomValues(buf);
+    return CODE_CHARS[buf[0] % CODE_CHARS.length];
+  }
+  return CODE_CHARS[Math.floor(Math.random() * CODE_CHARS.length)];
+}
+
+export function makeRoomCode(length = 6, existing?: Set<string> | string[]) {
+  const existingSet = existing ? (existing instanceof Set ? existing : new Set(existing)) : new Set<string>();
+  let attempt = '';
+  do {
+    attempt = '';
+    for (let i = 0; i < length; i++) {
+      attempt += pickChar();
+    }
+  } while (existingSet.has(attempt));
+  existingSet.add(attempt);
+  return attempt;
+}


### PR DESCRIPTION
## Summary
- add controller abstraction with a local hotseat controller and refactored network controller
- update the lobby and play UI to support choosing hotseat or network room-code play, with bot management and clean mode switching
- replace direct crypto.randomUUID usage with compatibility ID and room code utilities to support older runtimes

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6947699cf2a48322b5e109626d6c9b38)