### PR TITLE
Improve WebSocket stability and diagnostics

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const PORT = Number(process.env.ROOM_PORT ?? '8787');
 const HOST = '0.0.0.0';
 
 const rooms = new Map();
+let nextSocketId = 1;
 
 const wss = new WebSocketServer({ host: HOST, port: PORT });
 
@@ -25,17 +26,32 @@ function broadcast(roomCode, message, origin) {
   }
 }
 
-wss.on('connection', (socket) => {
+wss.on('connection', (socket, request) => {
+  const socketId = nextSocketId++;
+  const remoteAddress = request?.socket?.remoteAddress ?? '<unknown>';
   let joinedRoom = null;
+  let joinedOnce = false;
+  const heartbeat = setInterval(() => {
+    if (socket.readyState === socket.OPEN) {
+      socket.ping();
+    }
+  }, 20000);
+
+  log(`socket ${socketId} connected from ${remoteAddress}`);
 
   socket.on('message', (data) => {
     try {
       const parsed = JSON.parse(data.toString());
       if (parsed.type === 'join-room') {
+        if (joinedOnce) {
+          log(`socket ${socketId} duplicate join ignored for ${joinedRoom ?? parsed.roomCode}`);
+          return;
+        }
         joinedRoom = parsed.roomCode;
+        joinedOnce = true;
         if (!rooms.has(joinedRoom)) rooms.set(joinedRoom, new Set());
         rooms.get(joinedRoom).add(socket);
-        log('client joined', joinedRoom, 'current', rooms.get(joinedRoom).size);
+        log(`socket ${socketId} joined ${joinedRoom} current ${rooms.get(joinedRoom).size} from ${remoteAddress}`);
         socket.send(JSON.stringify({ type: 'joined-room', roomCode: joinedRoom }));
         return;
       }
@@ -45,21 +61,25 @@ wss.on('connection', (socket) => {
         return;
       }
     } catch (err) {
-      log('failed to process message', err);
+      log(`socket ${socketId} failed to process message`, err);
       socket.send(JSON.stringify({ type: 'error', message: 'Invalid message' }));
     }
   });
 
-  socket.on('close', () => {
+  socket.on('close', (code, reasonBuffer) => {
+    clearInterval(heartbeat);
+    const reason = reasonBuffer?.toString() || '<none>';
     if (joinedRoom && rooms.has(joinedRoom)) {
       rooms.get(joinedRoom).delete(socket);
       if (rooms.get(joinedRoom).size === 0) rooms.delete(joinedRoom);
-      log('client left', joinedRoom, 'remaining', rooms.get(joinedRoom)?.size ?? 0);
+      log(`socket ${socketId} closed code=${code} reason=${reason} room=${joinedRoom} remaining ${rooms.get(joinedRoom)?.size ?? 0}`);
+    } else {
+      log(`socket ${socketId} closed code=${code} reason=${reason} room=<none>`);
     }
   });
 
   socket.on('error', (err) => {
-    log('socket error', err);
+    log(`socket ${socketId} error`, err);
   });
 });
 

--- a/src/controllers/hotseatController.ts
+++ b/src/controllers/hotseatController.ts
@@ -54,10 +54,16 @@ export class HotseatController implements GameController {
 
   onStateChange(callback: (state: GameState) => void) {
     this.stateCallbacks.push(callback);
+    return () => {
+      this.stateCallbacks = this.stateCallbacks.filter((cb) => cb !== callback);
+    };
   }
 
   onPlayersChange(callback: (players: PlayerInfo[]) => void) {
     this.playerCallbacks.push(callback);
+    return () => {
+      this.playerCallbacks = this.playerCallbacks.filter((cb) => cb !== callback);
+    };
   }
 
   dispose() {

--- a/src/controllers/types.ts
+++ b/src/controllers/types.ts
@@ -8,9 +8,18 @@ export interface GameController {
   getPlayers(): PlayerInfo[];
   getAssignedPlayer(): PlayerInfo | null;
   submitAction(action: LegalAction): void;
-  onStateChange(callback: (state: GameState) => void): void;
-  onPlayersChange(callback: (players: PlayerInfo[]) => void): void;
-  onPlayerJoin?(callback: (player: PlayerInfo) => void): void;
+  onStateChange(callback: (state: GameState) => void): () => void;
+  onPlayersChange(callback: (players: PlayerInfo[]) => void): () => void;
+  onPlayerJoin?(callback: (player: PlayerInfo) => void): () => void;
+  onConnectionStatusChange?(
+    callback: (event: {
+      status: 'idle' | 'connecting' | 'connected' | 'reconnecting' | 'disconnected';
+      attempt?: number;
+      delayMs?: number;
+      code?: number;
+      reason?: string;
+    }) => void
+  ): () => void;
   setPlayers?(players: PlayerInfo[]): void;
   dispose(): void;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -35,6 +35,45 @@ body {
   margin: 1rem 0;
 }
 
+.connection-status {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin: 0.25rem 0;
+}
+
+.connection-status .status-detail {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.status-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  display: inline-block;
+}
+
+.status-dot.status-connected {
+  background: #22c55e;
+}
+
+.status-dot.status-connecting {
+  background: #eab308;
+}
+
+.status-dot.status-reconnecting {
+  background: #f97316;
+}
+
+.status-dot.status-disconnected {
+  background: #ef4444;
+}
+
+.status-dot.status-idle {
+  background: #94a3b8;
+}
+
 .play-area.disabled {
   pointer-events: none;
   opacity: 0.75;


### PR DESCRIPTION
## Summary
- add socket identifiers, heartbeat pings, and duplicate-join guards with detailed logging on the room server
- harden the NetworkController with connection status callbacks, reconnection backoff, and single join messages per connection
- show client connection status in the UI and avoid StrictMode-related duplicate controller sockets

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694864d099b08322b0efa3e9385a1c4c)