### PR TITLE
Allow configuring remote room server endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,18 @@ npm run dev
 Once it starts you will see a local URL such as `http://localhost:5173/`.
 In this environment open the “Web 5173” preview to launch the app in your browser.
 
+If you want clients on other devices or networks to reach the room server, expose it publicly (or on your LAN) and configure the
+ front end with its address:
+
+```bash
+# examples
+VITE_ROOM_SERVER_URL="ws://your.public.host:8787" npm run dev
+VITE_ROOM_SERVER_HOST=192.168.1.10 VITE_ROOM_SERVER_PORT=8787 npm run dev
+```
+
+`VITE_ROOM_SERVER_URL` overrides everything; otherwise `VITE_ROOM_SERVER_HOST` and `VITE_ROOM_SERVER_PORT` override the defaults
+ of `window.location.hostname` and `8787`.
+
 Run tests:
 
 ```bash

--- a/src/multiplayer/adapter.ts
+++ b/src/multiplayer/adapter.ts
@@ -85,9 +85,12 @@ export class NetworkController implements GameController {
   }
 
   private getRoomSocketUrl() {
-    const host = window.location.hostname;
+    const envUrl = import.meta.env.VITE_ROOM_SERVER_URL;
+    if (envUrl) return envUrl;
+
+    const host = import.meta.env.VITE_ROOM_SERVER_HOST || window.location.hostname;
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const port = 8787;
+    const port = import.meta.env.VITE_ROOM_SERVER_PORT || 8787;
     return `${protocol}://${host}:${port}`;
   }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,11 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_ROOM_SERVER_URL?: string;
+  readonly VITE_ROOM_SERVER_HOST?: string;
+  readonly VITE_ROOM_SERVER_PORT?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- allow overriding the room WebSocket URL/host/port via Vite environment variables for remote connections
- document how to point clients at a remote or LAN-exposed room server
- add env typings for the new configuration variables

## Testing
- npm test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694871e1c5d48322b103ba1e0ae27847)