### PR TITLE
Restore automatic local room server targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,8 @@ npm run dev
 Once it starts you will see a local URL such as `http://localhost:5173/`.
 In this environment open the “Web 5173” preview to launch the app in your browser.
 
-If you want clients on other devices or networks to reach the room server, expose it publicly (or on your LAN) and configure the
- front end with its address:
-
-```bash
-# examples
-VITE_ROOM_SERVER_URL="ws://your.public.host:8787" npm run dev
-VITE_ROOM_SERVER_HOST=192.168.1.10 VITE_ROOM_SERVER_PORT=8787 npm run dev
-```
-
-`VITE_ROOM_SERVER_URL` overrides everything; otherwise `VITE_ROOM_SERVER_HOST` and `VITE_ROOM_SERVER_PORT` override the defaults
- of `window.location.hostname` and `8787`.
+If you want clients on other devices or networks to reach the room server, expose it publicly (or on your LAN). The front end
+ will automatically connect to `ws(s)://<page-host>:8787`.
 
 Run tests:
 

--- a/src/multiplayer/adapter.ts
+++ b/src/multiplayer/adapter.ts
@@ -85,12 +85,9 @@ export class NetworkController implements GameController {
   }
 
   private getRoomSocketUrl() {
-    const envUrl = import.meta.env.VITE_ROOM_SERVER_URL;
-    if (envUrl) return envUrl;
-
-    const host = import.meta.env.VITE_ROOM_SERVER_HOST || window.location.hostname;
     const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
-    const port = import.meta.env.VITE_ROOM_SERVER_PORT || 8787;
+    const host = window.location.hostname;
+    const port = 8787;
     return `${protocol}://${host}:${port}`;
   }
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,9 +1,6 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_ROOM_SERVER_URL?: string;
-  readonly VITE_ROOM_SERVER_HOST?: string;
-  readonly VITE_ROOM_SERVER_PORT?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- remove environment overrides and always connect to the local room relay at the page host on port 8787
- simplify README instructions to reflect automatic local connection
- drop now-unused Vite environment declarations for room server overrides

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69487576fdd0832280d90d32a470f273)